### PR TITLE
Amdgpu fix

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -429,7 +429,7 @@ EGLImage egl_create_image_from_va(VASurfaceID* _va_surface, VADisplay va_display
     va_surface_attrib.type = VASurfaceAttribPixelFormat;
     va_surface_attrib.flags = VA_SURFACE_ATTRIB_SETTABLE;
     va_surface_attrib.value.type = VAGenericValueTypeInteger;
-    va_surface_attrib.value.value.i = VA_FOURCC_RGBA;
+    va_surface_attrib.value.value.i = VA_FOURCC_BGRA;
 
     r = vaCreateSurfaces( va_display, VA_RT_FORMAT_RGB32, width, height, &va_surface, 1, &va_surface_attrib, 1 );
     if( r != VA_STATUS_SUCCESS )

--- a/src/util.h
+++ b/src/util.h
@@ -11,7 +11,7 @@
 
 typedef void *GLeglImageOES;
 typedef void (*PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)(GLenum target, GLeglImageOES image);
-PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
+extern PFNGLEGLIMAGETARGETTEXTURE2DOESPROC glEGLImageTargetTexture2DOES;
 
 int texture2d_to_jpeg( GLuint tex, int level, const char* filename );
 int texture_2d_load_from_file( GLuint* tex, const char* filename );


### PR DESCRIPTION
This branch contains the compiling fix with GCC 10 and a fix for video encoding on AMDGPU (tested with Mesa 20.3.5).
Also still works on Intel GPUs (tested on a Intel HD 4000)